### PR TITLE
Fix report error, by vectorizing it

### DIFF
--- a/model/Metrics.py
+++ b/model/Metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def tab2pitch_internal(tab):
+def tab2pitch(tab):
     pitch_vector = np.zeros(44)
     string_pitches = [40, 45, 50, 55, 59, 64]
     for string_num in range(len(tab)):
@@ -8,11 +8,10 @@ def tab2pitch_internal(tab):
         fret_class = np.argmax(fret_vector, -1)
         # 0 means that the string is closed 
         if fret_class > 0:
+            # 21 + 64 - 41 = 44 is the max number
             pitch_num = fret_class + string_pitches[string_num] - 41
             pitch_vector[pitch_num] = 1
     return pitch_vector
-
-tab2pitch = np.vectorize(tab2pitch_internal)
 
 def tab2bin(tab):
     tab_arr = np.zeros((6,20))
@@ -24,6 +23,9 @@ def tab2bin(tab):
             fret_num = fret_class - 1
             tab_arr[string_num][fret_num] = 1
     return tab_arr
+
+tab2pitch = np.vectorize(tab2pitch, signature='(n,m) -> (k)')
+tab2bin = np.vectorize(tab2bin, signature='(n,m) -> (p,q)')
 
 def pitch_precision(pred, gt):
     pitch_pred = tab2pitch(pred)
@@ -47,16 +49,16 @@ def pitch_f_measure(pred, gt):
 
 def tab_precision(pred, gt):
     # get rid of "closed" class, as we only want to count positives
-    tab_pred = np.array(map(tab2bin,pred))
-    tab_gt = np.array(map(tab2bin,gt))
+    tab_pred = tab2bin(pred)
+    tab_gt = tab2bin(gt)
     numerator = np.sum(np.multiply(tab_pred, tab_gt).flatten())
     denominator = np.sum(tab_pred.flatten())
     return (1.0 * numerator) / denominator
 
 def tab_recall(pred, gt):
     # get rid of "closed" class, as we only want to count positives
-    tab_pred = np.array(map(tab2bin,pred))
-    tab_gt = np.array(map(tab2bin,gt))
+    tab_pred = tab2bin(pred)
+    tab_gt = tab2bin(gt)
     numerator = np.sum(np.multiply(tab_pred, tab_gt).flatten())
     denominator = np.sum(tab_gt.flatten())
     return (1.0 * numerator) / denominator

--- a/model/Metrics.py
+++ b/model/Metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def tab2pitch(tab):
+def tab2pitch_internal(tab):
     pitch_vector = np.zeros(44)
     string_pitches = [40, 45, 50, 55, 59, 64]
     for string_num in range(len(tab)):
@@ -11,6 +11,8 @@ def tab2pitch(tab):
             pitch_num = fret_class + string_pitches[string_num] - 41
             pitch_vector[pitch_num] = 1
     return pitch_vector
+
+tab2pitch = np.vectorize(tab2pitch_internal)
 
 def tab2bin(tab):
     tab_arr = np.zeros((6,20))
@@ -24,15 +26,15 @@ def tab2bin(tab):
     return tab_arr
 
 def pitch_precision(pred, gt):
-    pitch_pred = np.array(map(tab2pitch,pred))
-    pitch_gt = np.array(map(tab2pitch,gt))
+    pitch_pred = tab2pitch(pred)
+    pitch_gt = tab2pitch(gt)
     numerator = np.sum(np.multiply(pitch_pred, pitch_gt).flatten())
     denominator = np.sum(pitch_pred.flatten())
     return (1.0 * numerator) / denominator
 
 def pitch_recall(pred, gt):
-    pitch_pred = np.array(map(tab2pitch,pred))
-    pitch_gt = np.array(map(tab2pitch,gt))
+    pitch_pred = tab2pitch(pred)
+    pitch_gt = tab2pitch(gt)
     numerator = np.sum(np.multiply(pitch_pred, pitch_gt).flatten())
     denominator = np.sum(pitch_gt.flatten())
     return (1.0 * numerator) / denominator

--- a/model/TabCNN.py
+++ b/model/TabCNN.py
@@ -49,7 +49,8 @@ class TabCNN:
         self.metrics["tr"] = []
         self.metrics["tf"] = []
         self.metrics["tdr"] = []
-        self.metrics["data"] = ["g0","g1","g2","g3","g4","g5","mean","std dev"]
+        self.metrics["data"] = ["gr", # validation result from random data
+                                "mean","std dev"]
         
         if self.spec_repr == "c":
             self.input_shape = (192, self.con_win_size, 1)


### PR DESCRIPTION
## 🎨 Overview

- Tried to fix #4 

## 🌈 Details

- In python3, `map` is not no more list type, but `map` type, which cannot be treated by numpy properly.
- So modernized it by vectorizing it instead of `map`ping it.
  + set signature properly
- [X] ~But, it still have trouble in evaluation process~ Resolved
  <details>

  ```python
  Traceback (most recent call last):
  File "/Users/hyunggyujang/test/tensorflow-metal/model/TabCNN.py", line 209, in <modu
    tabcnn.evaluate()
  File "/Users/hyunggyujang/test/tensorflow-metal/model/TabCNN.py", line 167, in evalu
    self.metrics["pp"].append(pitch_precision(self.y_pred, self.y_gt))
  File "/Users/hyunggyujang/test/tensorflow-metal/model/Metrics.py", line 29, in pitch
    pitch_pred = tab2pitch(pred)
  File "/Users/hyunggyujang/test/tensorflow-metal/lib/python3.9/site-packages/numpy/li
    return self._vectorize_call(func=func, args=vargs)
  File "/Users/hyunggyujang/test/tensorflow-metal/lib/python3.9/site-packages/numpy/li
    ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
  File "/Users/hyunggyujang/test/tensorflow-metal/lib/python3.9/site-packages/numpy/li
    outputs = func(*inputs)
  File "/Users/hyunggyujang/test/tensorflow-metal/model/Metrics.py", line 6, in tab2pi
    for string_num in range(len(tab)):
  TypeError: object of type 'numpy.float32' has no len()
  ```
  </details>

## 🎯 Review Points

-

## 📚 References

-
